### PR TITLE
feat: implementação de rotas nomeadas com autenticação e passagem de parâmetros

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_2025/formulario.dart';
+import 'main.dart' show auth;
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home (privada)'),
+        actions: [
+          IconButton(
+            tooltip: 'Abrir Perfil (envia Map)',
+            onPressed: () {
+              // Exemplo de MAP a ser passado para a rota privada /perfil
+              final dadosUsuario = <String, String>{
+                'nomeCompleto': 'Enildo da Silva',
+                'dataNascimento': '15/04/1998',
+                'telefone': '(64) 99999-0000',
+              };
+              Navigator.pushNamed(context, '/perfil', arguments: dadosUsuario);
+            },
+            icon: const Icon(Icons.person),
+          ),
+          IconButton(
+            tooltip: 'Sair',
+            onPressed: () {
+              auth.logout();
+              Navigator.pushNamedAndRemoveUntil(context, '/login', (r) => false);
+            },
+            icon: const Icon(Icons.logout),
+          ),
+        ],
+      ),
+      // Reaproveitando seu formulário como corpo da Home
+      body: const Formulario(),
+    );
+  }
+}

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'main.dart' show auth;
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login (pública)')),
+      body: Center(
+        child: SizedBox(
+          width: 360,
+          child: Card(
+            elevation: 6,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('Autenticação simples para o exercício'),
+                  const SizedBox(height: 16),
+                  TextFormField(decoration: const InputDecoration(labelText: 'E-mail')),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    decoration: const InputDecoration(labelText: 'Senha'),
+                    obscureText: true,
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      icon: const Icon(Icons.login),
+                      label: const Text('Entrar'),
+                      onPressed: () {
+                        auth.login();
+                        Navigator.pushReplacementNamed(context, '/home');
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,93 @@
 import 'package:flutter/material.dart';
-import 'package:mobile_2025/formulario.dart';
+import 'package:mobile_2025/home_page.dart';
+import 'package:mobile_2025/login_page.dart';
+import 'package:mobile_2025/perfil_page.dart';
 
 void main() {
-  runApp(
-    const MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: Formulario(),
-    ),
-  );
+  runApp(const MyApp());
 }
 
+/// Serviço de autenticação MUITO simples (memória)
+class AuthService extends ChangeNotifier {
+  bool _logged = false;
+  bool get logged => _logged;
+
+  void login() {
+    _logged = true;
+    notifyListeners();
+  }
+
+  void logout() {
+    _logged = false;
+    notifyListeners();
+  }
+}
+
+/// Instância global só para o exercício (mantém simples)
+final auth = AuthService();
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: auth,
+      builder: (_, __) {
+        return MaterialApp(
+          debugShowCheckedModeBanner: false,
+          title: 'Rotas nomeadas (privadas)',
+          // começa no login (pública)
+          initialRoute: '/login',
+          onGenerateRoute: (settings) {
+            // Rotas privadas que exigem login:
+            final isPrivate = settings.name == '/home' || settings.name == '/perfil';
+
+            if (isPrivate && !auth.logged) {
+              // bloqueia e envia ao login
+              return MaterialPageRoute(
+                builder: (_) => const LoginPage(),
+                settings: const RouteSettings(name: '/login'),
+              );
+            }
+
+            switch (settings.name) {
+              case '/login':
+                return MaterialPageRoute(
+                  builder: (_) => const LoginPage(),
+                  settings: settings,
+                );
+              case '/home':
+                return MaterialPageRoute(
+                  builder: (_) => const HomePage(),
+                  settings: settings,
+                );
+              case '/perfil':
+                // Espera um Map como argumento
+                final args = settings.arguments;
+                if (args is! Map<String, String>) {
+                  // defesa simples para evitar crash se vier errado
+                  return MaterialPageRoute(
+                    builder: (_) => const Scaffold(
+                      body: Center(child: Text('Parâmetros inválidos para /perfil')),
+                    ),
+                  );
+                }
+                return MaterialPageRoute(
+                  builder: (_) => PerfilPage(dados: args),
+                  settings: settings,
+                );
+            }
+
+            // rota desconhecida
+            return MaterialPageRoute(
+              builder: (_) => const Scaffold(
+                body: Center(child: Text('Rota não encontrada')),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/perfil_page.dart
+++ b/lib/perfil_page.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+class PerfilPage extends StatelessWidget {
+  final Map<String, String> dados;
+
+  const PerfilPage({super.key, required this.dados});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Perfil (privada)')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Card(
+          elevation: 4,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: DefaultTextStyle.merge(
+              style: const TextStyle(fontSize: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Dados recebidos via Map:', style: TextStyle(fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 12),
+                  Text('Nome completo: ${dados['nomeCompleto'] ?? '-'}'),
+                  Text('Data de nascimento: ${dados['dataNascimento'] ?? '-'}'),
+                  Text('Telefone: ${dados['telefone'] ?? '-'}'),
+                  const SizedBox(height: 20),
+                  FilledButton.icon(
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.arrow_back),
+                    label: const Text('Voltar'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Rotas criadas:

/login → rota pública (tela de login simples com botão "Entrar")

/home → rota privada (reutiliza o componente Formulario)

/perfil → rota privada que recebe um Map<String, String> com dados de usuário (nome completo, data de nascimento e telefone) e os exibe na tela

Funcionalidades implementadas:

Controle de autenticação simples via AuthService em memória

Bloqueio de acesso às rotas privadas quando não autenticado (redireciona automaticamente para /login)

Passagem de parâmetros do tipo Map para a rota /perfil

Logout direto pelo botão na AppBar da Home

Navegação intuitiva entre as telas